### PR TITLE
Update ED.drc.r

### DIFF
--- a/R/ED.drc.R
+++ b/R/ED.drc.R
@@ -49,7 +49,10 @@ display = TRUE, pool = TRUE, logBase = NULL, multcomp = FALSE, intType = "confid
 #    } else {
 #        vcMat <- vcov(object, od = od, pool = pool)
 #    }
-    vcMat <- vcov.(object)
+    #vcMat <- vcov.(object)
+    if (is.function(vcov.)) 
+            vcMat <- vcov.(object)
+        else vcMat <- vcov.
     
     ## Defining vectors and matrices needed
     ncolIM <- ncol(indexMat)


### PR DESCRIPTION
The proposed change would allow the user to enter either a function or a variance-covariance matrix. This is useful to be able e.g. to use the vcovCL() function, which requires a 'cluster' argument. At the moment, the 'cluster' argument is not accepted by the ED() function, but, once the proposed change is incorporated, the user will be able to use the vcovCL() function to calculate a cluster robust variance-covariance matrix and pass it to the ED() function as an argument.