### PR TITLE
bug fix for issue #10

### DIFF
--- a/R/plot.drc.R
+++ b/R/plot.drc.R
@@ -57,9 +57,10 @@ normal = FALSE, normRef = 1, confidence.level = 0.95)
     {
         names(resp) <- seq(length(resp))
         respList <- split(resp, curveid)
+        
         respNorm <- mapply(normalizeLU, respList, 
-                              as.list(as.data.frame(getLU(object))), 
-                              normRef = normRef, SIMPLIFY = F)
+                           as.list(as.data.frame(getLU(object)))[names(respList)], 
+                           normRef = normRef, SIMPLIFY = F)
         
         resp <- do.call(c, unname(respNorm))[as.character(seq(length(resp)))]
 #        respNew <- unlist(mapply(normalizeLU, respList, as.list(as.data.frame(getLU(object)))))    
@@ -765,13 +766,13 @@ getLU <- function(object)
 {
     parmMat <- object$"parmMat"
 #    rownames(parmMat) <- object$"parNames"[[2]]
-
     fixedVal <- object$fct$fixed
     lenFV <- length(fixedVal)
 #    parmMatExt <- matrix(NA, length(fixedVal), ncol(parmMat))
     parmMatExt <- matrix(fixedVal, length(fixedVal), ncol(parmMat))
     parmMatExt[is.na(fixedVal), ] <- parmMat
 
+    colnames(parmMatExt) <- colnames(parmMat)
     parmMatExt
 }
 

--- a/R/plot.drc.R
+++ b/R/plot.drc.R
@@ -55,13 +55,13 @@ normal = FALSE, normRef = 1, confidence.level = 0.95)
     ## Normalizing the response values
     if (normal)
     {
-        
+        names(resp) <- seq(length(resp))
         respList <- split(resp, curveid)
-        resp <- unlist(mapply(normalizeLU, respList, 
+        respNorm <- mapply(normalizeLU, respList, 
                               as.list(as.data.frame(getLU(object))), 
-                              normRef = normRef))
+                              normRef = normRef, SIMPLIFY = F)
         
-        resp <- resp[,levels(curveid)[order(match(levels(curveid), curveid))]] #reoder response to match original order
+        resp <- do.call(c, unname(respNorm))[as.character(seq(length(resp)))]
 #        respNew <- unlist(mapply(normalizeLU, respList, as.list(as.data.frame(getLU(object)))))    
 #        print(respNew)
 #        print(resp)
@@ -251,16 +251,17 @@ normal = FALSE, normRef = 1, confidence.level = 0.95)
 #        predictMat <- predict(object, interval = "confidence")[, 3:4]
 #        predictMat <- predict(object, interval = "confidence")[, c("Lower", "Upper")]
         predictMat <- predict(object, interval = "confidence",
-                              level = confidence.level)[, c("Lower", "Upper")]  
+                              level = confidence.level)[, c("Lower", "Upper")]
         
         if(normal) {
+          names(predictMat) <- seq(length(predictMat))
           predictList <- split(predictMat, curveid)
-          
           predictMatListNorm <- mapply(normalizeLU, predictList, 
                                 as.list(as.data.frame(getLU(object))), 
                                 normRef = normRef, 
                                 SIMPLIFY = F)
-          predictMat<- do.call(rbind,lapply(predictMatListNorm, matrix, ncol = 2))
+          predictMatNorm <- do.call(c, unname(predictMatListNorm))[as.character(seq(length(predictMat)))]
+          predictMat<- matrix(predictMatNorm, ncol = 2)
         }
 #        print(predictMat)
     

--- a/R/plot.drc.R
+++ b/R/plot.drc.R
@@ -55,10 +55,13 @@ normal = FALSE, normRef = 1, confidence.level = 0.95)
     ## Normalizing the response values
     if (normal)
     {
+        
         respList <- split(resp, curveid)
         resp <- unlist(mapply(normalizeLU, respList, 
                               as.list(as.data.frame(getLU(object))), 
-                              normRef = normRef))            
+                              normRef = normRef))
+        
+        resp <- resp[,levels(curveid)[order(match(levels(curveid), curveid))]] #reoder response to match original order
 #        respNew <- unlist(mapply(normalizeLU, respList, as.list(as.data.frame(getLU(object)))))    
 #        print(respNew)
 #        print(resp)
@@ -248,7 +251,17 @@ normal = FALSE, normRef = 1, confidence.level = 0.95)
 #        predictMat <- predict(object, interval = "confidence")[, 3:4]
 #        predictMat <- predict(object, interval = "confidence")[, c("Lower", "Upper")]
         predictMat <- predict(object, interval = "confidence",
-                              level = confidence.level)[, c("Lower", "Upper")]        
+                              level = confidence.level)[, c("Lower", "Upper")]  
+        
+        if(normal) {
+          predictList <- split(predictMat, curveid)
+          
+          predictMatListNorm <- mapply(normalizeLU, predictList, 
+                                as.list(as.data.frame(getLU(object))), 
+                                normRef = normRef, 
+                                SIMPLIFY = F)
+          predictMat<- do.call(rbind,lapply(predictMatListNorm, matrix, ncol = 2))
+        }
 #        print(predictMat)
     
         barFct <- function(plotPoints)


### PR DESCRIPTION
I've made two additions to the plot.drc function to fix the issues raised in #10. 

The first fix is in the normalization block where previously the points would be reordered in alphabetical order by curveid; causing the curves to deviate from the plotted points. To prevent this behavior, each response is named by the order it appeared in the input data, normalized, then reordered by name to ensure it matches the original order. 

The second fix is in the `type = 'bars'` code block. If `normal == TRUE`, the error bars are normalized using the same normalization code as before. Note that this may result in error bars that dip below 0 or above 1. 

See code below for examples:
```{r}
library(drc)
library(dplyr)
mydata <- read.csv("repex.csv")

silly.order <- data.frame(col = c(1:12), 
                          col.silly = c(1,4,7,10,
                                        2,5,8,11,
                                        3,6,9,12))


mydata <- mydata %>%
  left_join(silly.order) %>%
  arrange(col.silly)

drc.model <-  drm(abs ~ conc, drug, data = mydata, fct = LL.4())

plot(drc.model, 
     type = "all",
     normal = F, 
     col = T, 
     broken = T, 
)
```
![image](https://user-images.githubusercontent.com/22528952/76229972-052bf180-61f1-11ea-9790-6a1e7dcdda1b.png)

```{r}
plot(drc.model, 
     type = "all",
     normal = T, 
     col = T, 
     broken = T, 
)
```
![image](https://user-images.githubusercontent.com/22528952/76229996-0eb55980-61f1-11ea-9df0-f9c9e832e25c.png)

```{r}

plot(drc.model, 
     type = "bars",
     normal = T, 
     col = T, 
     broken = T, 
)
```
![image](https://user-images.githubusercontent.com/22528952/76230006-1543d100-61f1-11ea-8d26-b88357762d56.png)
